### PR TITLE
always use -DPentiumCPS insteado -DWALL, patch out CPU throttling check for recent ATLAS versions

### DIFF
--- a/easybuild/easyblocks/a/atlas.py
+++ b/easybuild/easyblocks/a/atlas.py
@@ -81,8 +81,8 @@ class EB_ATLAS(ConfigureMake):
                 # apply patch to ignore CPU throttling: make ProbeCPUThrottle always return 0
                 # see http://sourceforge.net/p/math-atlas/support-requests/857/
                 cfg_file = os.path.join('CONFIG', 'src', 'config.c')
-                for line in fileinput.input(cfgfile, inplace=1, backup='.orig.eb'):
-                    line = re.sub(r"^(\s*iret)\s*=\s*.*CPU THROTTLE.*$" % k, r"\1 = 0;", line)
+                for line in fileinput.input(cfg_file, inplace=1, backup='.orig.eb'):
+                    line = re.sub(r"^(\s*iret)\s*=\s*.*CPU THROTTLE.*$", r"\1 = 0;", line)
                     sys.stdout.write(line)
             self.log.warning('CPU throttling check ignored: NOT recommended!')
 


### PR DESCRIPTION
This enabled building ATLAS 3.10.1 on both Scientific Linux 5 and 6, even when throttling is enabled.

To be included in https://github.com/hpcugent/easybuild-easyblocks/pull/258 by merging this in.
