### PR TITLE
fall back to ALL as value for components for icc/ifort 2016.x (+ style fixes)

### DIFF
--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -339,13 +339,15 @@ class IntelBase(EasyBlock):
             'install_mode_name': silent_cfg_names_map.get('install_mode_name', INSTALL_MODE_NAME_2015),
         }
 
-        if self.install_components:
+        if self.install_components is not None:
             if len(self.install_components) == 1 and self.install_components[0] in [COMP_ALL, COMP_DEFAULTS]:
                 # no quotes should be used for ALL or DEFAULTS
                 silent += 'COMPONENTS=%s\n' % self.install_components[0]
-            else:
+            elif self.install_components:
                 # a list of components is specified (needs quotes)
                 silent += 'COMPONENTS="' + ';'.join(self.install_components) + '"\n'
+            else:
+                raise EasyBuildError("Empty list of components specified")
 
         if silent_cfg_extras is not None:
             if isinstance(silent_cfg_extras, dict):

--- a/easybuild/easyblocks/generic/intelbase.py
+++ b/easybuild/easyblocks/generic/intelbase.py
@@ -347,7 +347,7 @@ class IntelBase(EasyBlock):
                 # a list of components is specified (needs quotes)
                 silent += 'COMPONENTS="' + ';'.join(self.install_components) + '"\n'
             else:
-                raise EasyBuildError("Empty list of components specified")
+                raise EasyBuildError("Empty list of matching components obtained via %s", self.cfg['components'])
 
         if silent_cfg_extras is not None:
             if isinstance(silent_cfg_extras, dict):

--- a/easybuild/easyblocks/i/icc.py
+++ b/easybuild/easyblocks/i/icc.py
@@ -38,7 +38,8 @@ import os
 import re
 from distutils.version import LooseVersion
 
-from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, LICENSE_FILE_NAME_2012
+from easybuild.easyblocks.generic.intelbase import IntelBase, ACTIVATION_NAME_2012, COMP_ALL
+from easybuild.easyblocks.generic.intelbase import LICENSE_FILE_NAME_2012
 from easybuild.easyblocks.t.tbb import get_tbb_gccprefix
 from easybuild.tools.run import run_cmd
 
@@ -66,6 +67,12 @@ class EB_icc(IntelBase):
         super(EB_icc, self).__init__(*args, **kwargs)
 
         self.debuggerpath = None
+
+        if LooseVersion(self.version) >= LooseVersion('2016') and self.cfg['components'] is None:
+            # we need to use 'ALL' by default, using 'DEFAULTS' results in key things not being installed (e.g. bin/icc)
+            self.cfg['components'] = [COMP_ALL]
+            self.log.debug("Nothing specified for components, but required for version 2016, using %s instead",
+                           self.cfg['components'])
 
     def install_step(self):
         """

--- a/easybuild/easyblocks/i/icc.py
+++ b/easybuild/easyblocks/i/icc.py
@@ -204,7 +204,7 @@ class EB_icc(IntelBase):
         return guesses
 
     def make_module_extra(self):
-        """Custom variables for OpenBabel module."""
+        """Additional custom variables for icc: $INTEL_PYTHONHOME."""
         txt = super(EB_icc, self).make_module_extra()
         if self.debuggerpath:
             intel_pythonhome = os.path.join(self.installdir, self.debuggerpath, 'python', 'intel64')

--- a/easybuild/easyblocks/i/ifort.py
+++ b/easybuild/easyblocks/i/ifort.py
@@ -57,7 +57,6 @@ class EB_ifort(EB_icc, IntelBase):
                 binprefix = 'bin'
             elif LooseVersion(self.version) >= LooseVersion('2013_sp1'):
                 binprefix = 'bin'
-                libprefix = 'lib/intel64'
             else:
                 libprefix = 'compiler/lib/intel64'
 

--- a/easybuild/easyblocks/i/imkl.py
+++ b/easybuild/easyblocks/i/imkl.py
@@ -321,16 +321,16 @@ class EB_imkl(IntelBase):
         mklfiles = None
         mkldirs = None
         ver = LooseVersion(self.version)
-        libs = ["libmkl_core.so", "libmkl_gnu_thread.so", "libmkl_intel_thread.so", "libmkl_sequential.so"]
-        extralibs = ["libmkl_blacs_intelmpi_%(suff)s.so", "libmkl_scalapack_%(suff)s.so"]
+        libs = ['libmkl_core.so', 'libmkl_gnu_thread.so', 'libmkl_intel_thread.so', 'libmkl_sequential.so']
+        extralibs = ['libmkl_blacs_intelmpi_%(suff)s.so', 'libmkl_scalapack_%(suff)s.so']
 
         if self.cfg['interfaces']:
-	    compsuff = '_intel'
-	    if get_software_root('icc') is None:
-		if get_software_root('GCC'):
-		    compsuff = '_gnu'
-		else:
-		    raise EasyBuildError("Not using Intel compilers or GCC, don't know compiler suffix for FFTW libraries.")
+            compsuff = '_intel'
+            if get_software_root('icc') is None:
+                if get_software_root('GCC'):
+                    compsuff = '_gnu'
+                else:
+                    raise EasyBuildError("Not using Intel/GCC, don't know compiler suffix for FFTW libraries.")
 
             precs = ['_double', '_single']
             if ver < LooseVersion('11'):
@@ -358,27 +358,27 @@ class EB_imkl(IntelBase):
             if self.cfg['m32']:
                 raise EasyBuildError("Sanity check for 32-bit not implemented yet for IMKL v%s (>= 10.3)", self.version)
             else:
-                mkldirs = ["bin", "mkl/bin", "mkl/lib/intel64", "mkl/include"]
+                mkldirs = ['bin', 'mkl/bin', 'mkl/lib/intel64', 'mkl/include']
                 if ver < LooseVersion('11.3'):
-                    mkldirs.append("mkl/bin/intel64")
+                    mkldirs.append('mkl/bin/intel64')
                 libs += [lib % {'suff': suff} for lib in extralibs for suff in ['lp64', 'ilp64']]
-                mklfiles = ["mkl/lib/intel64/libmkl.so", "mkl/include/mkl.h"] + \
-                           ["mkl/lib/intel64/%s" % lib for lib in libs]
+                mklfiles = ['mkl/lib/intel64/libmkl.so', 'mkl/include/mkl.h'] + \
+                           ['mkl/lib/intel64/%s' % lib for lib in libs]
                 if ver >= LooseVersion('10.3.4') and ver < LooseVersion('11.1'):
-                    mkldirs += ["compiler/lib/intel64"]
+                    mkldirs += ['compiler/lib/intel64']
                 else:
-                    mkldirs += ["lib/intel64"]
+                    mkldirs += ['lib/intel64']
 
         else:
             if self.cfg['m32']:
-                mklfiles = ["lib/32/libmkl.so", "include/mkl.h"] + \
-                           ["lib/32/%s" % lib for lib in libs]
-                mkldirs = ["lib/32", "include/32", "interfaces"]
+                mklfiles = ['lib/32/libmkl.so', 'include/mkl.h'] + \
+                           ['lib/32/%s' % lib for lib in libs]
+                mkldirs = ['lib/32', 'include/32', 'interfaces']
             else:
                 libs += [lib % {'suff': suff} for lib in extralibs for suff in ['lp64', 'ilp64']]
-                mklfiles = ["lib/em64t/libmkl.so", "include/mkl.h"] + \
-                           ["lib/em64t/%s" % lib for lib in libs]
-                mkldirs = ["lib/em64t", "include/em64t", "interfaces"]
+                mklfiles = ['lib/em64t/libmkl.so', 'include/mkl.h'] + \
+                           ['lib/em64t/%s' % lib for lib in libs]
+                mkldirs = ['lib/em64t', 'include/em64t', 'interfaces']
 
         custom_paths = {
             'files': mklfiles,


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyblocks/pull/756

with this in place, and the components listed for icc/ifort as shown in https://github.com/hpcugent/easybuild-easyconfigs/pull/2209, I can install `intel/2016.00` and HPL v2.1 on top of it

additionally, testing with existing versions of icc/ifort/impi/imkl/tbb/ipp reveals no problems

unless any problems pop up with further testing, all required changes should now be there in the easyblocks
